### PR TITLE
LOGGLY-3903 Remove prompts to run 'verify' action

### DIFF
--- a/configure-syslog.py
+++ b/configure-syslog.py
@@ -1321,13 +1321,9 @@ def install(current_environment):
 
 def verify(current_environment):
     Logger.printLog("Verification started", prio = 'debug')
-
     perform_sanity_check_and_get_product_for_configuration(current_environment)
-
     loggly_user, loggly_password, loggly_subdomain = login()
-
     doverify(loggly_user, loggly_password, loggly_subdomain)
-
     Logger.printLog("Verification completed", prio = 'debug')
 
 def uninstall(current_environment):


### PR DESCRIPTION
When users run the install script as shown in our docs, the
install-script is never saved to disk, so users cannot re-run the
script with any 'verify' action.

We should not advertise an action they cannot run without
re-downloading the script.
