### PR TITLE
LOGGLY-3979 Add 'Debian' to list of supported Linux

### DIFF
--- a/configure-syslog.py
+++ b/configure-syslog.py
@@ -363,6 +363,7 @@ def get_os_id(os_name):
         'fedora': OS_FEDORA,
         'red hat enterprise linux server': OS_RHEL,
         'centos': OS_CENTOS,
+        'debian': OS_UBUNTU,
         }.get(os_name.lower(), OS_UNSUPPORTED)
 
 def get_syslog_id(product_name):


### PR DESCRIPTION
Debian => 6.0 ("Squeeze") installs rsyslog by default.
http://debian-handbook.info/browse/wheezy/sect.syslog.html

**Still needs testing, Ivan's downloading a Debian 7 image to test this. Please help test this if you already have a Debian => 6.0 ready to roll.**
