### PR TITLE
import with statements from the future

### DIFF
--- a/configure-syslog.py
+++ b/configure-syslog.py
@@ -14,6 +14,8 @@
 # (c) Copyright Loggly 2013.
 ######################################################################
 
+from __future__ import with_statement
+
 import os, os.path
 import platform
 import re


### PR DESCRIPTION
this will allow the script to _load_ in Python 2.5

and display an error explaining that the script is only supported
under python >=2.6
