### PR TITLE
Incorrect Login URL, results in 404

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -214,7 +214,7 @@ setLinuxVariables()
 checkIfLogglyServersAccessible()
 {
 	echo "INFO: Checking if $LOGGLY_ACCOUNT_URL is reachable."
-	if [ $(curl -s --head  --request GET $LOGGLY_ACCOUNT_URL/login | grep "200 OK" | wc -l) == 1 ]; then
+	if [ $(curl -s --head  --request GET $LOGGLY_ACCOUNT_URL/accounts/login | grep "200 OK" | wc -l) == 1 ]; then
 		echo "INFO: $LOGGLY_ACCOUNT_URL is reachable."
 	else
 		logMsgToConfigSysLog "WARNING" "WARNING: $LOGGLY_ACCOUNT_URL is not reachable. Please check your network and firewall settings. Continuing to configure Loggly on your system."


### PR DESCRIPTION
Changed the account login URL check to the appropriate login page. Currently, checking `$LOGGLY_ACCOUNT_URL/login` results in a 404 which causes the script to fail.
