### PR TITLE
Fixed bug causing script to hang

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -567,7 +567,7 @@ createRsyslogDir()
 checkIfLogsMadeToLoggly()
 {
 	logMsgToConfigSysLog "INFO" "INFO: Sending test message to Loggly."
-	uuid=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+	uuid=$(cat /proc/sys/kernel/random/uuid)
 
 	queryParam="syslog.appName%3ALOGGLYVERIFY%20$uuid"
 	logger -t "LOGGLYVERIFY" "LOGGLYVERIFY-Test message for verification with UUID $uuid"


### PR DESCRIPTION
The original 'cat /dev/urandom' method caused the script to hang indefinitely on my system. Given that Linux has UUID generation built in at the kernel level, I see no reason to use such a hackish method.