### PR TITLE
Add TLS support for file monitoring

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -553,25 +553,19 @@ action(type=\"omfwd\" protocol=\"tcp\" target=\"$LOGS_01_HOST\" port=\"$LOGGLY_S
 #     -------------------------------------------------------
 	"
 if [ "$RSYSLOG_VERSION_TMP" -le "7" ]; then
-				/bin/bash -c "sudo $PKG_MGR install rsyslog-gnutls -y"
-				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ];
-				then
-				logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package was not downloaded. Please download it and then run the script again."
-				exit 1
-				fi
                 inputStrTls=$inputStr_TLS_RSYS_7
 elif [ "$RSYSLOG_VERSION_TMP" -ge "8" ]; then
-				/bin/bash -c "sudo $PKG_MGR install rsyslog-gnutls -y"
-				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ];
-				then
-				logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package was not downloaded. Please download it and then run the script again."
-				exit 1
-				fi
                 inputStrTls=$inputStr_TLS_RSYS_8
 fi
 inputStr=$inputStr_NO_TLS
 if [ $LOGGLY_TLS_SENDING == "true" ]; then
 	downloadTlsCerts
+	/bin/bash -c "sudo $PKG_MGR install rsyslog-gnutls -y"
+				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ];
+				then
+				logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package was not downloaded. Please download it and then run the script again."
+				exit 1
+				fi
 	inputStr=$inputStrTls
 fi
 }

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -15,7 +15,7 @@ function ctrl_c()  {
 #name of the current script. This will get overwritten by the child script which calls this
 SCRIPT_NAME=configure-linux.sh
 #version of the current script. This will get overwritten by the child script which calls this
-SCRIPT_VERSION=1.16
+SCRIPT_VERSION=1.17
 
 #application tag. This will get overwritten by the child script which calls this
 APP_TAG=
@@ -73,12 +73,12 @@ LOGGLY_PASSWORD=
 SUPPRESS_PROMPT="false"
 
 #variables used in 22-loggly.conf file
-LOGGLY_SYSLOG_PORT=514
+LOGGLY_SYSLOG_PORT=6514
 LOGGLY_DISTRIBUTION_ID="41058"
 
 #Instruction link on how to configure loggly on linux manually. This will get overwritten by the child script which calls this
 #on how to configure the child application
-MANUAL_CONFIG_INSTRUCTION="Manual instructions to configure rsyslog on Linux are available at https://www.loggly.com/docs/rsyslog-manual-configuration/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/"
+MANUAL_CONFIG_INSTRUCTION="Manual instructions to configure rsyslog on Linux are available at https://www.loggly.com/docs/rsyslog-tls-configuration/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/"
 
 #this variable is set if the script is invoked via some other calling script
 IS_INVOKED=
@@ -88,6 +88,9 @@ LINUX_ENV_VALIDATED="false"
 
 #this variable will inform if verification needs to be performed
 LINUX_DO_VERIFICATION="true"
+
+#this variable will enable sending logs over TLS
+LOGGLY_TLS_SENDING="true"
 
 ##########  Variable Declarations - End  ##########
 
@@ -150,11 +153,11 @@ installLogglyConf()
 		checkLinuxLogglyCompatibility
 	fi
 
-	#create rsyslog dir if it doesn't exist, Modify the permission on rsyslog directory if exist on Ubuntu
-	createRsyslogDir
-
 	#if all the above check passes, write the 22-loggly.conf file
 	checkAuthTokenAndWriteContents
+
+	#create rsyslog dir if it doesn't exist, Modify the permission on rsyslog directory if exist on Ubuntu
+	createRsyslogDir
 
 	if [ "$LINUX_DO_VERIFICATION" = "true" ]; then
 		#check if the logs are going to loggly fro linux system now
@@ -215,18 +218,23 @@ checkIfSupportedOS()
 	case "$LINUX_DIST_IN_LOWER_CASE" in
 		*"ubuntu"* )
 		echo "INFO: Operating system is Ubuntu."
+		PKG_MGR="apt-get"
 		;;
 		*"redhat"* )
 		echo "INFO: Operating system is Red Hat."
+		PKG_MGR="yum"
 		;;
 		*"centos"* )
 		echo "INFO: Operating system is CentOS."
+		PKG_MGR="yum"
 		;;
 		*"debian"* )
 		echo "INFO: Operating system is Debian."
+		PKG_MGR="apt-get"
 		;;
 		*"amazon"* )
 		echo "INFO: Operating system is Amazon AMI."
+		PKG_MGR="yum"
 		;;
 		*"darwin"* )
 		#if the OS is mac then exit
@@ -468,32 +476,113 @@ checkAuthTokenAndWriteContents()
 	fi
 }
 
-
-#write the contents to 22-loggly.conf file
-writeContents()
+downloadTlsCerts()
 {
+	echo "DOWNLOADING CERTIFICATE"
+	mkdir -pv /etc/rsyslog.d/keys/ca.d
+	curl -O https://logdog.loggly.com/media/logs-01.loggly.com_sha12.crt
+	sudo cp -Prf logs-01.loggly.com_sha12.crt /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+	sudo rm logs-01.loggly.com_sha12.crt
+	if [ ! -f /etc/rsyslog.d/keys/ca.d//logs-01.loggly.com_sha12.crt ]; then
+	logMsgToConfigSysLog "ERROR" "ERROR: Certificate could not be downloaded."
+	exit 1
+	fi
+}
 
-WRITE_SCRIPT_CONTENTS="false"
-inputStr="
+confString()
+{
+	RSYSLOG_VERSION_TMP=$(echo $RSYSLOG_VERSION | cut -d "." -f1 )
+	inputStr_TLS_RSYS_7="
 #          -------------------------------------------------------
-#          Syslog Logging Directives for Loggly ($1.loggly.com)
+#          Syslog Logging Directives for Loggly ($LOGGLY_ACCOUNT.loggly.com)
 #          -------------------------------------------------------
-
+##########################################################
+### RsyslogTemplate for Loggly ###
+##########################################################
+\$template LogglyFormat,\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@$LOGGLY_DISTRIBUTION_ID tag=\\\"RsyslogTLS\\\"] %msg%\n\"
+# Setup disk assisted queues
+\$WorkDirectory /var/spool/rsyslog # where to place spool files
+\$ActionQueueFileName fwdRule1     # unique name prefix for spool files
+\$ActionQueueMaxDiskSpace 1g       # 1gb space limit (use as much as possible)
+\$ActionQueueSaveOnShutdown on     # save messages to disk on shutdown
+\$ActionQueueType LinkedList       # run asynchronously
+\$ActionResumeRetryCount -1        # infinite retries if host is down
+#RsyslogGnuTLS
+\$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+\$ActionSendStreamDriver gtls
+\$ActionSendStreamDriverMode 1
+\$ActionSendStreamDriverAuthMode x509/name
+\$ActionSendStreamDriverPermittedPeer *.loggly.com
+*.* @@$LOGS_01_HOST:$LOGGLY_SYSLOG_PORT;LogglyFormat
+#################END CONFIG FILE#########################
+	"
+	inputStr_TLS_RSYS_8="
+#          -------------------------------------------------------
+#          Syslog Logging Directives for Loggly ($LOGGLY_ACCOUNT.loggly.com)
+#          -------------------------------------------------------
+# Setup disk assisted queues
+\$WorkDirectory /var/spool/rsyslog # where to place spool files
+\$ActionQueueFileName fwdRule1     # unique name prefix for spool files
+\$ActionQueueMaxDiskSpace 1g       # 1gb space limit (use as much as possible)
+\$ActionQueueSaveOnShutdown on     # save messages to disk on shutdown
+\$ActionQueueType LinkedList       # run asynchronously
+\$ActionResumeRetryCount -1        # infinite retries if host is down
+#RsyslogGnuTLS
+\$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+template(name=\"LogglyFormat\" type=\"string\"
+string=\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@$LOGGLY_DISTRIBUTION_ID tag=\\\"RsyslogTLS\\\"] %msg%\n\"
+)
+# Send messages to Loggly over TCP using the template.
+action(type=\"omfwd\" protocol=\"tcp\" target=\"$LOGS_01_HOST\" port=\"$LOGGLY_SYSLOG_PORT\" template=\"LogglyFormat\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" StreamDriverPermittedPeers=\"*.loggly.com\")
+	"
+	
+	inputStr_NO_TLS="
+#          -------------------------------------------------------
+#          Syslog Logging Directives for Loggly ($LOGGLY_ACCOUNT.loggly.com)
+#          -------------------------------------------------------
 # Define the template used for sending logs to Loggly. Do not change this format.
-\$template LogglyFormat,\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$2@$3] %msg%\n\"
-
+\$template LogglyFormat,\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@$LOGGLY_DISTRIBUTION_ID tag=\\\"Rsyslog\\\"] %msg%\n\"
 \$WorkDirectory /var/spool/rsyslog # where to place spool files
 \$ActionQueueFileName fwdRule1 # unique name prefix for spool files
 \$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
 \$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
 \$ActionQueueType LinkedList   # run asynchronously
 \$ActionResumeRetryCount -1    # infinite retries if host is down
-
 # Send messages to Loggly over TCP using the template.
-*.*             @@$4:$5;LogglyFormat
-
+*.*             @@$LOGS_01_HOST:$LOGGLY_SYSLOG_PORT;LogglyFormat
 #     -------------------------------------------------------
-"
+	"
+if [ "$RSYSLOG_VERSION_TMP" -le "7" ]; then
+				/bin/bash -c "sudo $PKG_MGR install rsyslog-gnutls -y"
+				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ];
+				then
+				logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package was not downloaded. Please download it and then run the script again."
+				exit 1
+				fi
+                inputStrTls=$inputStr_TLS_RSYS_7
+elif [ "$RSYSLOG_VERSION_TMP" -ge "8" ]; then
+				/bin/bash -c "sudo $PKG_MGR install rsyslog-gnutls -y"
+				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ];
+				then
+				logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package was not downloaded. Please download it and then run the script again."
+				exit 1
+				fi
+                inputStrTls=$inputStr_TLS_RSYS_8
+fi
+inputStr=$inputStr_NO_TLS
+if [ $LOGGLY_TLS_SENDING == "true" ]; then
+	downloadTlsCerts
+	inputStr=$inputStrTls
+fi
+}
+
+#write the contents to 22-loggly.conf file
+writeContents()
+{
+checkIfTLS
+confString
+WRITE_SCRIPT_CONTENTS="false"
+
 	if [ -f "$LOGGLY_RSYSLOG_CONFFILE" ]; then
 		logMsgToConfigSysLog "INFO" "INFO: Loggly rsyslog file $LOGGLY_RSYSLOG_CONFFILE already exist."
 
@@ -534,7 +623,7 @@ inputStr="
 	else
 		WRITE_SCRIPT_CONTENTS="true"
 	fi
-
+	
 	if [ "$WRITE_SCRIPT_CONTENTS" == "true" ]; then
 
 cat << EOIPFW >> $LOGGLY_RSYSLOG_CONFFILE
@@ -753,11 +842,42 @@ getPassword()
 	echo
 }
 
+#Change TLS settings
+checkIfTLS()
+{
+   if [[ $LOGGLY_SYSLOG_PORT == 514 ]]; then
+   
+        if [ "$SUPPRESS_PROMPT" == "false" ]; then
+	        while true;
+			do
+	            read -p "Hey you are going to setup system logs in insecure mode. Do you want to overwrite this with secure mode? (yes/no)" yn
+						case $yn in
+						[Yy]* )
+							logMsgToConfigSysLog "INFO" "INFO: Going to overwrite the conf file: $LOGGLY_RSYSLOG_CONFFILE with secure configuration";
+							LOGGLY_TLS_SENDING="true"
+							LOGGLY_SYSLOG_PORT=6514
+							break;;
+						[Nn]* )
+							LINUX_DO_VERIFICATION="false"
+							logMsgToConfigSysLog "INFO" "INFO: Skipping Linux verification."
+							break;;
+						* ) echo "Please answer yes or no.";;
+						esac
+			done			
+		else
+		    logMsgToConfigSysLog "WARN" "WARN: Your system logs are being send insecurely. We prefer to send system logs securely so switching to secure configuration."
+			LOGGLY_TLS_SENDING="true"
+			LOGGLY_SYSLOG_PORT=6514
+			
+	    fi
+    fi		
+}
+
 #display usage syntax
 usage()
 {
 cat << EOF
-usage: configure-linux [-a loggly auth account or subdomain] [-t loggly token (optional)] [-u username] [-p password (optional)] [-s suppress prompts {optional)]
+usage: configure-linux [-a loggly auth account or subdomain] [-t loggly token (optional)] [-u username] [-p password (optional)] [-s suppress prompts {optional)] [--insecure {to send logs without TLS} (optional)]
 usage: configure-linux [-a loggly auth account or subdomain] [-r to remove]
 usage: configure-linux [-h for help]
 EOF
@@ -791,6 +911,10 @@ if [ "$1" != "being-invoked" ]; then
 				;;
 			-s | --suppress )
 				SUPPRESS_PROMPT="true"
+				;;
+			     --insecure )
+				LOGGLY_TLS_SENDING="false"
+				LOGGLY_SYSLOG_PORT=514
 				;;
 			-h | --help)
 				usage

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -856,13 +856,12 @@ checkIfTLS()
 						* ) echo "Please answer yes or no.";;
 						esac
 			done			
-		else
-       logMsgToConfigSysLog "WARN" "WARN: Your system logs are being send insecurely. We prefer to send system logs securely so switching to secure configuration."
+	    else
+		    logMsgToConfigSysLog "WARN" "WARN: Your system logs are being send insecurely. We prefer to send system logs securely so switching to secure configuration."
 			LOGGLY_TLS_SENDING="true"
 			LOGGLY_SYSLOG_PORT=6514
 			
-	     fi
-
+	    fi
     fi		
 }
 

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -2,7 +2,7 @@
 
 #downloads configure-linux.sh
 echo "INFO: Downloading dependencies - configure-linux.sh"
-curl -s -o configure-linux.sh https://github.com/Shwetajain148/install-script/blob/tls-support-filemonitoring/Linux%20Script/configure-linux.sh
+curl -s -o configure-linux.sh https://raw.githubusercontent.com/Shwetajain148/install-script/tls-support-filemonitoring/Linux%20Script/configure-linux.sh
 source configure-linux.sh "being-invoked"
 
 ##########  Variable Declarations - Start  ##########

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -427,8 +427,10 @@ write21ConfFileContents()
 			\$InputFileSeverity info
 			\$InputFilePersistStateInterval 20000
 			\$InputRunFileMonitor
+			
 			#Add a tag for file events
 			template (name=\"$CONF_FILE_FORMAT_NAME\" type=\"string\" string=\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@41058 $TAG] %msg%\n\")
+			
 			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then action(type=\"omfwd\" protocol=\"tcp\" target=\"logs-01.loggly.com\" port=\"6514\" template=\"$CONF_FILE_FORMAT_NAME\")
 			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then stop
 		"
@@ -436,6 +438,7 @@ write21ConfFileContents()
 			\$ModLoad imfile
 			\$InputFilePollInterval 10
 			\$WorkDirectory $RSYSLOG_DIR
+			
 			# File access file:
 			\$InputFileName $FILE_TO_MONITOR
 			\$InputFileTag $LOGGLY_FILE_TO_MONITOR_ALIAS
@@ -443,8 +446,10 @@ write21ConfFileContents()
 			\$InputFileSeverity info
 			\$InputFilePersistStateInterval 20000
 			\$InputRunFileMonitor
+			
 			#Add a tag for file events
 			template (name=\"$CONF_FILE_FORMAT_NAME\" type=\"string\" string=\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@41058 $TAG] %msg%\n\")
+			
 			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then action(type=\"omfwd\" protocol=\"tcp\" target=\"logs-01.loggly.com\" port=\"514\" template=\"$CONF_FILE_FORMAT_NAME\")
 			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then stop
 		"

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -466,10 +466,8 @@ write21ConfFileContents()
 			}
 		"
 		imfileStrNonTls="
-			\$ModLoad imfile
-			\$InputFilePollInterval 10
-			\$WorkDirectory $RSYSLOG_DIR
-			module(load="imfile")
+		
+			module(load=\"imfile\")
 
 			# Input for FILE1
 			input(type=\"imfile\" tag=\"$LOGGLY_FILE_TO_MONITOR_ALIAS\" ruleset=\"filelog\" file=\"$FILE_TO_MONITOR\") #wildcard is allowed at file level only

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -154,7 +154,7 @@ constructFileVariables()
 	FILE_SYSLOG_CONFFILE="$RSYSLOG_ETCDIR_CONF/21-filemonitoring-$FILE_ALIAS.conf"
 
 	#conf file backup name
-	FILE_SYSLOG_CONFFILE_BACKUP="$FILE_ALIAS.loggly.bk"
+	FILE_SYSLOG_CONFFILE_BACKUP="$RSYSLOG_ETCDIR_CONF/$FILE_ALIAS.loggly.bk"
 
 	#application tag
 	APP_TAG="\"file-alias\":\"$LOGGLY_FILE_TO_MONITOR_ALIAS\""

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -2,7 +2,7 @@
 
 #downloads configure-linux.sh
 echo "INFO: Downloading dependencies - configure-linux.sh"
-curl -s -o configure-linux.sh https://raw.githubusercontent.com/Shwetajain148/install-script/Add-TLS-Support/Linux%20Script/configure-linux.sh 
+curl -s -o configure-linux.sh https://github.com/Shwetajain148/install-script/blob/tls-support-filemonitoring/Linux%20Script/configure-linux.sh
 source configure-linux.sh "being-invoked"
 
 ##########  Variable Declarations - Start  ##########

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -9,7 +9,7 @@ source configure-linux.sh "being-invoked"
 #name of the current script
 SCRIPT_NAME=configure-file-monitoring.sh
 #version of the current script
-SCRIPT_VERSION=1.13
+SCRIPT_VERSION=1.14
 
 #file to monitor (contains complete path and file name) provided by user
 LOGGLY_FILE_TO_MONITOR=

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -2,7 +2,7 @@
 
 #downloads configure-linux.sh
 echo "INFO: Downloading dependencies - configure-linux.sh"
-curl -s -o configure-linux.sh https://raw.githubusercontent.com/Shwetajain148/install-script/tls-support-filemonitoring/Linux%20Script/configure-linux.sh
+curl -s -o configure-linux.sh https://www.loggly.com/install/configure-linux.sh
 source configure-linux.sh "being-invoked"
 
 ##########  Variable Declarations - Start  ##########

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -446,7 +446,7 @@ write21ConfFileContents()
 			#Add a tag for file events
 			template (name=\"$CONF_FILE_FORMAT_NAME\" type=\"string\" string=\"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [$LOGGLY_AUTH_TOKEN@41058 $TAG] %msg%\n\")
 			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then action(type=\"omfwd\" protocol=\"tcp\" target=\"logs-01.loggly.com\" port=\"514\" template=\"$CONF_FILE_FORMAT_NAME\")
-			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then ~
+			if \$programname == '$LOGGLY_FILE_TO_MONITOR_ALIAS' then stop
 		"
 	else
 		imfileStr="


### PR DESCRIPTION
I changed configure-linux.sh and configure-file-monitoring.sh scripts to add TLS support to both the scripts.

These are covering below points.

* Added TLS support to configure-linux.sh file 
* Added TLS support to configure-file-monitoring.sh file
  - Check if 6514 is open
  - Add insecure parameter
  - Prompt if we should switch to insecure mode if system logs are insecure, or overwrite them with secure mode
  - If silent or no prompt mode is on and system logs are insecure, log a warning and overwrite system config with secure settings 
      