### PR TITLE
switch-to-insecure-mode-if-tlsdownload-fails

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -458,8 +458,9 @@ checkIfSelinuxServiceEnforced()
 	if [ $? -ne 0 ]; then
 		logMsgToConfigSysLog "INFO" "INFO: selinux status is not enforced."
 	elif [ $(getenforce | grep "Enforcing" | wc -l) -gt 0 ]; then
-		logMsgToConfigSysLog "ERROR" "ERROR: selinux status is 'Enforcing'. Please disable it and start the rsyslog daemon manually."
-		exit 1
+	        logMsgToConfigSysLog "Info" "Info: selinux status is 'Enforcing'. Setting it to the permissive mode and restarting the rsyslog daemon."
+		setenforce 0
+		restartRsyslog
 	fi
 }
 
@@ -875,7 +876,7 @@ searchAndFetch()
 {
 	url=$2
 
-	result=$(wget -qO- /dev/null --user "$LOGGLY_USERNAME" --password "$LOGGLY_PASSWORD" "$url")
+	result=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $url)
 
 	if [ -z "$result" ]; then
 		logMsgToConfigSysLog "ERROR" "ERROR: Please check your network/firewall settings & ensure Loggly subdomain, username and password is specified correctly."
@@ -889,7 +890,7 @@ searchAndFetch()
 	url="$LOGGLY_ACCOUNT_URL/apiv2/events?rsid=$id"
 
 	# retrieve the data
-	result=$(wget -qO- /dev/null --user "$LOGGLY_USERNAME" --password "$LOGGLY_PASSWORD" "$url")
+	result=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $url)
 	count=$(echo "$result" | grep total_events | awk '{print $2}')
 	count="${count%\,}"
 	eval $1="'$count'"
@@ -1021,4 +1022,3 @@ fi
 ##########  Get Inputs from User - End  ##########       -------------------------------------------------------
 #          End of Syslog Logging Directives for Loggly
 #
-

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -458,9 +458,8 @@ checkIfSelinuxServiceEnforced()
 	if [ $? -ne 0 ]; then
 		logMsgToConfigSysLog "INFO" "INFO: selinux status is not enforced."
 	elif [ $(getenforce | grep "Enforcing" | wc -l) -gt 0 ]; then
-	        logMsgToConfigSysLog "Info" "Info: selinux status is 'Enforcing'. Setting it to the permissive mode and restarting the rsyslog daemon."
-		setenforce 0
-		restartRsyslog
+	        logMsgToConfigSysLog "ERROR" "ERROR: selinux status is 'Enforcing'. Please manually restart the rsyslog daemon or turn off selinux by running `setenforce 0` and then rerun the script."
+		exit 1
 	fi
 }
 

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -102,7 +102,7 @@ checkLinuxLogglyCompatibility()
 	checkIfUserHasRootPrivileges
 
 	#check if the OS is supported by the script. If no, then exit
-    checkIfSupportedOS
+        checkIfSupportedOS
 	
 	#check if package-manager is installed
 	checkIfPackageManagerIsInstalled
@@ -596,14 +596,14 @@ if [ $LOGGLY_TLS_SENDING == "true" ]; then
 	 
 	    if [ $(rpm -qa | grep -c "rsyslog-gnutls") -eq 0 ]; then                               
                                 logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package could not be installed automatically. Please install it and then run the script again. Manual instructions to configure rsyslog are available at https://www.loggly.com/docs/rsyslog-tls-configuration/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/."
-                                exit 1		    
+                                exit 1
 	    fi 
 	
     
 	  elif [ "$PKG_MGR" == "apt-get" ]; then
 	
 				if [ $(dpkg-query -W -f='${Status}' rsyslog-gnutls 2>/dev/null | grep -c "ok installed") -eq 0 ]; then                            
-                                logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package could not be installed automatically. Please install it and then run the script again. Manual instructions to configure rsyslog are available at https://www.loggly.com/docs/rsyslog-tls-configuration/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/."								
+                                logMsgToConfigSysLog "ERROR" "ERROR: The rsyslog-gnutls package could not be installed automatically. Please install it and then run the script again. Manual instructions to configure rsyslog are available at https://www.loggly.com/docs/rsyslog-tls-configuration/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/."
                                 exit 1
                 fi	
       elif [ "$FORCE_SECURE" == "true" ]; then
@@ -634,7 +634,8 @@ if [ "$DEPENDENCIES_INSTALLED" == "false" ]; then
 							LOGGLY_SYSLOG_PORT=514
 							break;;
 						[Nn]* )
-							break;;
+						    logMsgToConfigSysLog "INFO" "INFO: Since the rsyslog-gnutls package could not be installed automatically, please install it yourself and then re-run the script using the --force-secure flag. This option will force the secure TLS configuration instead of falling back on insecure mode. It is useful for Linux distributions where this script cannot automatically detect the dependency using yum or apt-get.";
+							exit 1;;
 						* ) echo "Please answer yes or no.";;
 						esac
 			done			
@@ -947,7 +948,7 @@ checkIfTLS()
 usage()
 {
 cat << EOF
-usage: configure-linux [-a loggly auth account or subdomain] [-t loggly token (optional)] [-u username] [-p password (optional)] [-s suppress prompts {optional)] [--insecure {to send logs without TLS} (optional)]
+usage: configure-linux [-a loggly auth account or subdomain] [-t loggly token (optional)] [-u username] [-p password (optional)] [-s suppress prompts {optional)] [--insecure {to send logs without TLS} (optional)[--force-secure {optional} ]
 usage: configure-linux [-a loggly auth account or subdomain] [-r to remove]
 usage: configure-linux [-h for help]
 EOF
@@ -1020,3 +1021,4 @@ fi
 ##########  Get Inputs from User - End  ##########       -------------------------------------------------------
 #          End of Syslog Logging Directives for Loggly
 #
+

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -458,7 +458,7 @@ checkIfSelinuxServiceEnforced()
 	if [ $? -ne 0 ]; then
 		logMsgToConfigSysLog "INFO" "INFO: selinux status is not enforced."
 	elif [ $(getenforce | grep "Enforcing" | wc -l) -gt 0 ]; then
-	        logMsgToConfigSysLog "ERROR" "ERROR: selinux status is 'Enforcing'. Please manually restart the rsyslog daemon or turn off selinux by running `setenforce 0` and then rerun the script."
+	        logMsgToConfigSysLog "ERROR" "ERROR: selinux status is 'Enforcing'. Please manually restart the rsyslog daemon or turn off selinux by running 'setenforce 0' and then rerun the script."
 		exit 1
 	fi
 }

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -15,7 +15,7 @@ function ctrl_c()  {
 #name of the current script. This will get overwritten by the child script which calls this
 SCRIPT_NAME=configure-linux.sh
 #version of the current script. This will get overwritten by the child script which calls this
-SCRIPT_VERSION=1.17
+SCRIPT_VERSION=1.18
 
 #application tag. This will get overwritten by the child script which calls this
 APP_TAG=

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -110,6 +110,9 @@ checkLinuxLogglyCompatibility()
 	#set the basic variables needed by this script
 	setLinuxVariables
 
+	#check if curl is not installed. If yes, ask user to install it manually and run the script again.
+	checkIfCurlIsNotInstalled
+
 	#check if the Loggly servers are accessible. If no, ask user to check network connectivity & exit
 	checkIfLogglyServersAccessible
 
@@ -302,6 +305,15 @@ setLinuxVariables()
 
 	#set loggly account url
 	LOGGLY_ACCOUNT_URL=https://$LOGGLY_ACCOUNT.loggly.com
+}
+
+#check if curl is not installed
+checkIfCurlIsNotInstalled()
+{
+        if ! [ -x "$(command -v curl)" ]; then
+	        logMsgToConfigSysLog "ERROR" "ERROR: 'Curl' is not installed on your machine, please install it manually and then run the script again.";
+	        exit 1
+        fi
 }
 
 #checks if all the various endpoints used for configuring loggly are accessible


### PR DESCRIPTION
@mchaudhary @mostlyjason,  I have modified code to implement below requirements in the script:
1. If TLS package couldn't be installed then the script will show a warning message "**The rsyslog-gnutls package could not be download automatically because your package manager could not be found.**" and will prompt to switch to insecure mode.(In **prompt mode**)
2. If TLS package couldn't be installed then the script will automatically install the insecure mode.(In **suppress mode**)
3. I have added a new flag **--force-secure** that will first show a warning message "**The rsyslog-gnutls package could not be download automatically because your package manager could not be found. Please install it and restart the rsyslog service to send logs to Loggly.**" and then will install the secure mode in case of failure attempt of installing TLS package.

The **--force-secure** parameter will set the TLS configuration and when the user installs the rsyslog-gnutls package manually and restart the rsyslog service, logs will reach to Loggly. I tested this functionality.

Please review.

I have started working on testing part of the script and updating a sheet accordingly. 