### PR TITLE
Add systemctl command to check for apache service

### DIFF
--- a/Modular Scripts/Apache2/configure-apache.sh
+++ b/Modular Scripts/Apache2/configure-apache.sh
@@ -113,7 +113,11 @@ checkApacheDetails()
 	getApacheServiceName
 	
 	#verify if apache is installed as service
-	if [ ! -f /etc/init.d/$SERVICE ]; then
+	if [ -f /etc/init.d/$SERVICE ]; then
+               logMsgToConfigSysLog "INFO" "INFO: Apache is present as a service."
+	elif [[ $(which systemctl) && $(systemctl list-unit-files $SERVICE.service | grep "$SERVICE.service") ]] &>/dev/null; then
+		logMsgToConfigSysLog "INFO" "INFO: Apache is present as a service."
+	else
 		logMsgToConfigSysLog "ERROR" "ERROR: Apache is not configured as a service"
 		exit 1
 	fi


### PR DESCRIPTION
@mchaudhary @mostlyjason In this PR, I have added a new systemctl command that will check whether any service is installed or not. The output of the command **systemctl list-unit-files httpd.service** is below(if installed):

```
UNIT FILE     STATE
httpd.service disabled

1 unit files listed.
```

If not installed then the output is as below:

```
UNIT FILE STATE

0 unit files listed.
```

So I used `grep` to extract the installed service name from the command output. I also used `$(which systemctl)` because on CentOS 6, systemctl command doesn't work and if user has not installed the httpd and run our script then it will first evaluate the condition `if [ -f /etc/init.d/$SERVICE ]; then` and it will not find the httpd service at that path then script will try to execute the next conditon in which systemctl command is used which doesn't work on CentOS 6 and give the message like below:

```
INFO: rsyslog is present as service.
INFO: Modified $MaxMessageSize to 64k in rsyslog.conf
configure-apache.sh: line 118: systemctl: command not found
ERROR: Apache is not configured as a service
Manual instructions to configure Apache2 is available at https://www.loggly.com/docs/sending-apache-logs/. Rsyslog troubleshooting instructions are available at https://www.loggly.com/docs/troubleshooting-rsyslog/
```

I had to remove `configure-apache.sh: line 118: systemctl: command not found` that's why I used `$(which systemctl)`, it will check if system is systemctl supported then this conditon will be executed otherwise not. 

I have tested on 
(a) CentOS 6 
(b) CentOS 7 
(c) Ubuntu 14
(d) Ubuntu 16

And the changes looked fine to me. Currently, I need to test on some other distributions as well. 

Please review