### PR TITLE
Check and switch existing logging mode

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -333,7 +333,8 @@ checkIfLogglyServersAccessible()
 	fi
 
 	echo "INFO: Checking if $LOGS_01_HOST is reachable."
-	if [ $(sleep 1 | telnet $LOGS_01_HOST $LOGGLY_SYSLOG_PORT 2>/dev/null | grep Connected | wc -l) == 1 ]; then
+	(</dev/tcp/$LOGS_01_HOST/$LOGGLY_SYSLOG_PORT) > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
 		echo "INFO: $LOGS_01_HOST is reachable."
 	else
 		logMsgToConfigSysLog "ERROR" "ERROR: $LOGS_01_HOST is not reachable. Please check your network and firewall settings."

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -938,7 +938,7 @@ getPassword()
 switchSystemLoggingToInsecure()
 {
 	if [ -f $LOGGLY_RSYSLOG_CONFFILE ]; then
-		EXISTING_SYSLOG_PORT=$(egrep -ow 6514 $LOGGLY_RSYSLOG_CONFFILE)
+		EXISTING_SYSLOG_PORT=$(grep -Eow 6514 $LOGGLY_RSYSLOG_CONFFILE)
 			if [[ $EXISTING_SYSLOG_PORT == 6514 ]]; then
 				if [ "$SUPPRESS_PROMPT" == "false" ]; then
 					while true;
@@ -969,7 +969,7 @@ switchSystemLoggingToInsecure()
 switchSystemLoggingToSecure()
 {
 	if [ -f $LOGGLY_RSYSLOG_CONFFILE ]; then
-		EXISTING_SYSLOG_PORT=$(egrep -ow 514 $LOGGLY_RSYSLOG_CONFFILE)
+		EXISTING_SYSLOG_PORT=$(grep -Eow 514 $LOGGLY_RSYSLOG_CONFFILE)
 			if [[ $EXISTING_SYSLOG_PORT == 514 ]]; then
 				if [ "$SUPPRESS_PROMPT" == "false" ]; then
 					while true;


### PR DESCRIPTION
@mchaudhary @mostlyjason, In this PR, I am checking whether the user is running the dependent scripts in **secure** or **insecure** mode, based on the script running mode, I am checking if the existing port in **22-loggly.conf** file is same as the running mode of the script For example if the user is running the **file-monitoring** script in **secure mode** but **22-loggly.conf** is set with **insecure** config then the script will prompt to switch **system config to secure mode as well and vice versa**. 

Please review. 