### PR TITLE
Add admin args option

### DIFF
--- a/AWSscripts/SQS3script.py
+++ b/AWSscripts/SQS3script.py
@@ -74,7 +74,7 @@ except S3ResponseError, e:
     else:
         print e
         sys.exit()
-    
+
 
 
 region = bucket.get_location()
@@ -96,9 +96,9 @@ queue_name = conn.get_queue(sqsname)
 
 if "None" not in str(queue_name):
     #queue exists
-  
+
     queue_attr_raw = conn.get_queue_attributes(queue_name, attribute='All')
-    queue_attr = str(queue_attr_raw) 
+    queue_attr = str(queue_attr_raw)
 
     if s3bucket in queue_attr:
       print 'Bucket already exists in queue\'s policy'
@@ -106,17 +106,17 @@ if "None" not in str(queue_name):
     elif 'arn:aws:s3' in queue_attr:
         # append the bucket to the existing policy
         print "A bucket already exists in this queue's policy, appending this bucket to it"
-       
+
         start = '\"aws:SourceArn\":'
         end = '}}}'
         result = re.search('%s(.*)%s' % (start, end), queue_attr).group(1)
-        
-        
+
+
         leftbracketremoved = result.replace('[','')
         rightbracketremoved = leftbracketremoved.replace(']','')
 
         addon  = '[' + rightbracketremoved + ',' + '\"arn:aws:s3:*:*:' + s3bucket +'\"' +']'
-        
+
 
         text = """ {
           "Version": "2008-10-17",
@@ -132,7 +132,7 @@ if "None" not in str(queue_name):
               "Resource": "arn:aws:sqs:%s:%s:%s",
               "Condition": {
                 "ArnLike": {
-                  "aws:SourceArn": %s   
+                  "aws:SourceArn": %s
                 }
               }
             },
@@ -149,18 +149,18 @@ if "None" not in str(queue_name):
         }
         """ % (region, acnumber, queue_name, addon, acnumber, region, acnumber, queue_name)
 
-        
+
         parsed = json.loads(text)
-       
+
         conn.set_queue_attribute(queue_name, 'Policy', json.dumps(parsed))
 
-        # s3 bucket notification configuration 
+        # s3 bucket notification configuration
         client = boto3.client('s3', region)
 
 
         response = client.put_bucket_notification_configuration(
             Bucket=s3bucket,
-            NotificationConfiguration={ 
+            NotificationConfiguration={
                 "QueueConfigurations": [{
                  "Id": "Notification",
                  "Events": ["s3:ObjectCreated:*"],
@@ -169,7 +169,7 @@ if "None" not in str(queue_name):
             }
         )
 
-      
+
     else:
         conn.set_queue_attribute(queue_name, 'Policy', json.dumps({
           "Version": "2008-10-17",
@@ -201,13 +201,13 @@ if "None" not in str(queue_name):
           ]
         }))
 
-        # s3 bucket notification configuration 
+        # s3 bucket notification configuration
         client = boto3.client('s3', region)
 
 
         response = client.put_bucket_notification_configuration(
             Bucket=s3bucket,
-            NotificationConfiguration={ 
+            NotificationConfiguration={
                 "QueueConfigurations": [{
                  "Id": "Notification",
                  "Events": ["s3:ObjectCreated:*"],
@@ -216,17 +216,17 @@ if "None" not in str(queue_name):
             }
         )
 
-else: 
+else:
     # queue does not exist and no sqs queue name is passed
     if sqsname == None:
         sqsname = 'loggly-s3-queue'
-    
+
     queue_name = conn.get_queue(sqsname)
 
     # Default queue already exists
     if queue_name!= None:
         queue_attr_raw = conn.get_queue_attributes(queue_name, attribute='All')
-        queue_attr = str(queue_attr_raw) 
+        queue_attr = str(queue_attr_raw)
 
         if s3bucket in queue_attr:
           print 'Bucket already exists in queue\'s policy'
@@ -234,17 +234,17 @@ else:
         else:
             # append the bucket to the existing policy
             print "A bucket already exists in this queue's policy, appending this bucket to it"
-           
+
             start = '\"aws:SourceArn\":'
             end = '}}}'
             result = re.search('%s(.*)%s' % (start, end), queue_attr).group(1)
-            
-            
+
+
             leftbracketremoved = result.replace('[','')
             rightbracketremoved = leftbracketremoved.replace(']','')
 
             addon  = '[' + rightbracketremoved + ',' + '\"arn:aws:s3:*:*:' + s3bucket +'\"' +']'
-            
+
 
             text = """ {
               "Version": "2008-10-17",
@@ -260,7 +260,7 @@ else:
                   "Resource": "arn:aws:sqs:%s:%s:%s",
                   "Condition": {
                     "ArnLike": {
-                      "aws:SourceArn": %s   
+                      "aws:SourceArn": %s
                     }
                   }
                 },
@@ -277,18 +277,18 @@ else:
             }
             """ % (region, acnumber, sqsname, addon, acnumber, region, acnumber, sqsname)
 
-            
+
             parsed = json.loads(text)
-           
+
             conn.set_queue_attribute(queue_name, 'Policy', json.dumps(parsed))
 
-            # s3 bucket notification configuration 
+            # s3 bucket notification configuration
             client = boto3.client('s3', region)
 
 
             response = client.put_bucket_notification_configuration(
                 Bucket=s3bucket,
-                NotificationConfiguration={ 
+                NotificationConfiguration={
                     "QueueConfigurations": [{
                      "Id": "Notification",
                      "Events": ["s3:ObjectCreated:*"],
@@ -298,10 +298,10 @@ else:
             )
 
     else:
-        # create the default queue or the queue passed as a parameter          
+        # create the default queue or the queue passed as a parameter
         q = conn.create_queue(sqsname)
         queue_name = conn.get_queue(sqsname)
-  
+
         conn.set_queue_attribute(queue_name, 'Policy', json.dumps({
               "Version": "2008-10-17",
               "Id": "PolicyExample",
@@ -332,12 +332,12 @@ else:
               ]
             }))
 
-        # s3 bucket notification configuration 
+        # s3 bucket notification configuration
         client = boto3.client('s3', region)
 
         response = client.put_bucket_notification_configuration(
             Bucket=s3bucket,
-            NotificationConfiguration={ 
+            NotificationConfiguration={
                 "QueueConfigurations": [{
                  "Id": "Notification",
                  "Events": ["s3:ObjectCreated:*"],
@@ -354,37 +354,37 @@ iam = boto.connect_iam(access_key, secret_key)
 
 
 if user != None and user != '':
-    
+
     try:
         response  = iam.get_user(user)
         if 'get_user_response' in response:
             print 'IAM user %s already exists, appending the sqs queue and s3 bucket to this IAM user\'s policy' % user
-            
+
             existing_policy = str(iam.get_user_policy(user, 'LogglyUserPolicy'))
             existing_policy_decoded = urllib.unquote(existing_policy)
 
             s3Buckets = []
-            sqsQueues = [] 
+            sqsQueues = []
 
             response = iam.get_all_access_keys(user, max_items=1)
-            
+
             s = StringIO.StringIO(existing_policy_decoded)
             for line in s:
               if 'arn:aws:sqs' in line:
                 sqsQueues.append(line.strip().replace(",", ""))
               if 'arn:aws:s3' in line:
                 s3Buckets.append(line.strip().replace(",", ""))
-            
+
             # append current s3bucket and sqs queue
             sqsQueues.append('\"arn:aws:sqs:%s:%s:%s\"' % (region, acnumber, sqsname,))
             s3Buckets.append('\"arn:aws:s3:::%s/*\"' % (s3bucket))
-            s3Buckets.append('\"arn:aws:s3:::%s\"' % (s3bucket))    
+            s3Buckets.append('\"arn:aws:s3:::%s\"' % (s3bucket))
 
             sqsQueueAddOn=""
             for entry in sqsQueues:
               sqsQueueAddOn = sqsQueueAddOn + entry + ",\n"
 
-            
+
             s3BucketAddOn=""
             for entry in s3Buckets:
               s3BucketAddOn =  s3BucketAddOn + entry + ",\n"
@@ -421,10 +421,10 @@ if user != None and user != '':
 
             print ""
             print 'Appended! Please provide the access key and secret key for the IAM user %s in the form fields' % user
-        
+
     except BotoServerError, e:
         if "The user with name" in e.message and "cannot be found" in e.message :
-    
+
             # create an IAM user
             response = iam.create_user(user)
 
@@ -478,11 +478,11 @@ if user != None and user != '':
             response = iam.put_user_policy(user,
                                            'LogglyUserPolicy',
                                            policy_json)
-        else: 
-            
-            print(e.message)     
+        else:
 
-else:   
+            print(e.message)
+
+else:
     # create an IAM user
     user = 'loggly-s3-user'
 
@@ -490,32 +490,32 @@ else:
         response  = iam.get_user(user)
         if 'get_user_response' in response:
             print 'The default IAM user \'loggly-s3-user\' which the script creates already exists, appending the sqs queue and s3 bucket to this IAM user\'s policy'
-            
+
             existing_policy = str(iam.get_user_policy(user, 'LogglyUserPolicy'))
             existing_policy_decoded = urllib.unquote(existing_policy)
 
             s3Buckets = []
-            sqsQueues = [] 
+            sqsQueues = []
 
             response = iam.get_all_access_keys(user, max_items=1)
-            
+
             s = StringIO.StringIO(existing_policy_decoded)
             for line in s:
               if 'arn:aws:sqs' in line:
                 sqsQueues.append(line.strip().replace(",", ""))
               if 'arn:aws:s3' in line:
                 s3Buckets.append(line.strip().replace(",", ""))
-            
+
             # append current s3bucket and sqs queue
             sqsQueues.append('\"arn:aws:sqs:%s:%s:%s\"' % (region, acnumber, sqsname,))
             s3Buckets.append('\"arn:aws:s3:::%s/*\"' % (s3bucket))
-            s3Buckets.append('\"arn:aws:s3:::%s\"' % (s3bucket))    
+            s3Buckets.append('\"arn:aws:s3:::%s\"' % (s3bucket))
 
             sqsQueueAddOn=""
             for entry in sqsQueues:
               sqsQueueAddOn = sqsQueueAddOn + entry + ",\n"
 
-            
+
             s3BucketAddOn=""
             for entry in s3Buckets:
               s3BucketAddOn =  s3BucketAddOn + entry + ",\n"
@@ -546,13 +546,13 @@ else:
                 }
             ]
             }""" % (sqsQueueAddOn[:-2], s3BucketAddOn[:-2],)
-    
 
-            try: 
+
+            try:
               response = iam.put_user_policy(user, 'LogglyUserPolicy', policy_json)
             except Exception, e:
               print e
-      
+
             print ""
             print "Appended! Please provide the access key and secret key for the IAM user \'loggly-s3-user\' in the form fields"
 

--- a/AWSscripts/SQS3script.py
+++ b/AWSscripts/SQS3script.py
@@ -30,6 +30,8 @@ parser.add_option("--s3bucket", dest="s3bucket",
                   help="s3 bucket name")
 parser.add_option("--user", dest="user",
                   help="user")
+parser.add_option("--admin", dest="admin",
+                  help="admin user name")
 parser.add_option("--sqsname", dest="sqsname",
                   help="sqsname")
 
@@ -40,6 +42,7 @@ s3bucket = opts.s3bucket
 acnumber = opts.acnumber
 sqsname = opts.sqsname
 user = opts.user
+admin = opts.admin
 
 if acnumber.isdigit()==False:
     print "Please check your account number, it should only contain digits, no other characters."
@@ -51,12 +54,18 @@ access_key=''
 secret_key=''
 bucket=''
 
+credentials_name = admin if admin else "default"
+
 with open(os.environ['HOME'] + '/.aws/credentials') as f:
     for line in f:
-        if "aws_access_key_id" in line:
-             access_key = line.split("=",1)[1].strip()
-        if "aws_secret_access_key" in line:
-             secret_key = line.split("=",1)[1].strip()
+        if credentials_name in line:
+            for line in f:
+                if "aws_access_key_id" in line:
+                     access_key = line.split("=",1)[1].strip()
+                if "aws_secret_access_key" in line:
+                     secret_key = line.split("=",1)[1].strip()
+                     break
+
 
 if not access_key:
     print "Please check your ~/.aws/credentials file and make sure that access key and secret access key are set. Run aws configure to set them up"


### PR DESCRIPTION
AWS CLI `.aws/credentials` can have more than one user.  Previously, the script would default to the last set of access/secret keys, which may not have administrative privileges.  If the user does have multiple users, this will allow them to pass in the admin name with administrative permissions.

Note: This is different than "user" which will have access to the s3 bucket and not necessarily have admin privileges.

@Shwetajain148 can you please review.  Can you email Pankaj to test as well after approval/merge.

Thank you