### PR TITLE
use expanduser to get home path - fix for windows

### DIFF
--- a/AWSscripts/SQS3script.py
+++ b/AWSscripts/SQS3script.py
@@ -55,8 +55,9 @@ secret_key=''
 bucket=''
 
 credentials_name = admin if admin else "default"
+home = os.path.expanduser("~")
 
-with open(os.environ['HOME'] + '/.aws/credentials') as f:
+with open(home+ '/.aws/credentials') as f:
     for line in f:
         if credentials_name in line:
             for line in f:


### PR DESCRIPTION
`os.environ['HOME']` does not work on windows, `os.path.expanduser("~")` will work cross platform