### PR TITLE
LOG-6197 - Limit SQS permissions only to those really needed

### DIFF
--- a/AWSscripts/SQS3script.py
+++ b/AWSscripts/SQS3script.py
@@ -30,7 +30,12 @@ class AWS:
               "Principal": {
                 "AWS": "arn:aws:iam::%(account_number)s:root"
               },
-              "Action": "SQS:*",
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:GetQueueUrl",
+                "sqs:GetQueueAttributes",
+                "sqs:DeleteMessage"
+              ],
               "Resource": "%(queue_arn)s"
         }
         """
@@ -73,7 +78,10 @@ class AWS:
     {
         "Effect": "Allow",
         "Action": [
-            "sqs:*"
+            "sqs:ReceiveMessage",
+            "sqs:GetQueueUrl",
+            "sqs:GetQueueAttributes",
+            "sqs:DeleteMessage"
         ],
         "Resource": [
             "%(queue_arn)s"


### PR DESCRIPTION
We don't need all SQS permissions so we should set only those that are really needed. This PR limits that.