### PR TITLE
LOG-6073 Add default value for count search

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -898,6 +898,12 @@ searchAndFetch() {
   result=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $url)
   count=$(echo "$result" | grep total_events | awk '{print $2}')
   count="${count%\,}"
+
+  # If no result is fetched, return 0
+  isNumberRegex='^[0-9]+$'
+  if ! [[ $count =~ $isNumberRegex ]] ; then
+     count=0
+  fi
   eval $1="'$count'"
   if [ "$count" -gt 0 ]; then
     timestamp=$(echo "$result" | grep timestamp)


### PR DESCRIPTION
Resolves CI https://swicloud.atlassian.net/browse/LOG-7606
Just adds validation that `count`, which was fetched from our API, returns a valid number, if not, it means that no event were found, so set the value to `0`. Otherwise the script prints `configure-linux.sh: line 902: [: : integer expression expected` which is propagated further and the output doesn't look clean.