### PR TITLE
Revert "LOG-6073 Add default value for count search"

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -898,12 +898,6 @@ searchAndFetch() {
   result=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $url)
   count=$(echo "$result" | grep total_events | awk '{print $2}')
   count="${count%\,}"
-
-  # If no result is fetched, return 0
-  isNumberRegex='^[0-9]+$'
-  if ! [[ $count =~ $isNumberRegex ]] ; then
-     count=0
-  fi
   eval $1="'$count'"
   if [ "$count" -gt 0 ]; then
     timestamp=$(echo "$result" | grep timestamp)


### PR DESCRIPTION
This reverts commit e05e97753a8745949f7683813b7859fe41293f5e.

According to Jarvis:
Hi Jiri, I just wanted to inform you that it seems like the automatic script is not working properly. It is stuck at this area of the code
```
logMsgToConfigSysLog "INFO" "INFO: Verifying if the logs made it to Loggly."
logMsgToConfigSysLog "INFO" "INFO: Verification # $counter of total $maxCounter."
#get the final count of file logs for past 15 minutes
searchAndFetch fileLatestLogCount "$queryUrl"
let counter=$counter+1
```
I've tested this on two environment, one EC2 Linux 2 and Ubuntu image in AWS, both are stuck at the verification part



This happens [here](https://github.com/loggly/install-script/blob/e05e97753a8745949f7683813b7859fe41293f5e/Linux%20Script/configure-linux.sh#L760)