### PR TITLE
[LOG-8159] Use CA file with public root certificates

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -47,6 +47,8 @@ EXISTING_SYSLOG_PORT=
 HOST_NAME=
 #this variable will hold the name of the linux distribution
 LINUX_DIST=
+#this variable will hold the path to public root certificates
+CA_PATH="/etc/ssl/certs/ca-certificates.crt"
 
 #host name for logs-01.loggly.com
 LOGS_01_HOST=logs-01.loggly.com

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -48,7 +48,7 @@ HOST_NAME=
 #this variable will hold the name of the linux distribution
 LINUX_DIST=
 #this variable will hold the path to CA bundle
-CA_PATH="/etc/ssl/certs/ca-certificates.crt"
+CA_FILE_PATH="/etc/ssl/certs/ca-certificates.crt"
 
 #host name for logs-01.loggly.com
 LOGS_01_HOST=logs-01.loggly.com

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -539,7 +539,7 @@ confString() {
 \$ActionResumeRetryCount -1        # infinite retries if host is down
 
 #RsyslogGnuTLS
-\$DefaultNetstreamDriverCAFile $CA_PATH
+\$DefaultNetstreamDriverCAFile $CA_FILE_PATH
 \$ActionSendStreamDriver gtls
 \$ActionSendStreamDriverMode 1
 \$ActionSendStreamDriverAuthMode x509/name

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -503,16 +503,6 @@ checkAuthTokenAndWriteContents() {
   fi
 }
 
-downloadTlsCerts() {
-  echo "DOWNLOADING CERTIFICATE"
-  mkdir -pv /etc/rsyslog.d/keys/ca.d
-  curl -O https://logdog.loggly.com/media/logs-01.loggly.com_sha12.crt
-  sudo cp -Prf logs-01.loggly.com_sha12.crt /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
-  sudo rm logs-01.loggly.com_sha12.crt
-  if [ ! -f /etc/rsyslog.d/keys/ca.d//logs-01.loggly.com_sha12.crt ]; then
-    logMsgToConfigSysLog "ERROR" "ERROR: Certificate could not be downloaded."
-    exit 1
-  fi
 }
 
 confString() {
@@ -598,7 +588,6 @@ action(type=\"omfwd\" protocol=\"tcp\" target=\"$LOGS_01_HOST\" port=\"$LOGGLY_S
 #install the certificate and check if gnutls package is installed
 installTLSDependencies() {
   if [ $LOGGLY_TLS_SENDING == "true" ]; then
-    downloadTlsCerts
     if [ "$SUPPRESS_PROMPT" == "true" ]; then
       /bin/bash -c "sudo $PKG_MGR install -y rsyslog-gnutls"
     else

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -526,7 +526,7 @@ confString() {
 \$ActionResumeRetryCount -1        # infinite retries if host is down
 
 #RsyslogGnuTLS
-\$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+\$DefaultNetstreamDriverCAFile $CA_PATH
 \$ActionSendStreamDriver gtls
 \$ActionSendStreamDriverMode 1
 \$ActionSendStreamDriverAuthMode x509/name
@@ -548,7 +548,7 @@ confString() {
 \$ActionResumeRetryCount -1        # infinite retries if host is down
 
 #RsyslogGnuTLS
-\$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+\$DefaultNetstreamDriverCAFile $CA_PATH
 
 
 template(name=\"LogglyFormat\" type=\"string\"

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -47,7 +47,7 @@ EXISTING_SYSLOG_PORT=
 HOST_NAME=
 #this variable will hold the name of the linux distribution
 LINUX_DIST=
-#this variable will hold the path to public root certificates
+#this variable will hold the path to CA bundle
 CA_PATH="/etc/ssl/certs/ca-certificates.crt"
 
 #host name for logs-01.loggly.com

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -509,7 +509,7 @@ setPathToCABundle () {
     CA_FILE_PATH="/etc/ssl/certs/ca-certificates.crt"
     ;;
   *"red"* | *"centos"* | *"amazon"*)
-    CA_PATH="/etc/ssl/certs/ca-bundle.crt"
+    CA_FILE_PATH="/etc/ssl/certs/ca-bundle.crt"
     ;;
   *)
     logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to CA bundle of your linux distribution in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA bundle is '$CA_PATH'."

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -561,7 +561,7 @@ confString() {
 \$ActionResumeRetryCount -1        # infinite retries if host is down
 
 #RsyslogGnuTLS
-\$DefaultNetstreamDriverCAFile $CA_PATH
+\$DefaultNetstreamDriverCAFile $CA_FILE_PATH
 
 
 template(name=\"LogglyFormat\" type=\"string\"

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -512,7 +512,7 @@ setPathToCABundle () {
     CA_FILE_PATH="/etc/ssl/certs/ca-bundle.crt"
     ;;
   *)
-    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to CA bundle of your linux distribution in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA bundle is '$CA_PATH'."
+    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to CA bundle of your linux distribution in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA bundle is '$CA_FILE_PATH'."
     ;;
   esac
 }

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -512,7 +512,7 @@ setPathToCABundle () {
     CA_FILE_PATH="/etc/ssl/certs/ca-bundle.crt"
     ;;
   *)
-    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to CA bundle of your linux distribution in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA bundle is '$CA_FILE_PATH'."
+    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to the file with root CA certificates (usually stored in OS trust store) in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA file is '$CA_FILE_PATH'."
     ;;
   esac
 }

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -366,14 +366,6 @@ checkIfLogglyServersAccessible() {
     logMsgToConfigSysLog "ERROR" "ERROR: This is not a recognized subdomain. Please ask the account owner for the subdomain they signed up with. Please note that your subdomain is just the first string in your loggly account URL not the entire account name."
     exit 1
   fi
-
-  echo "INFO: Checking if Gen2 account."
-  if [ $(curl -s --head --request GET $LOGGLY_ACCOUNT_URL/apiv2/customer | grep "404 NOT FOUND" | wc -l) == 1 ]; then
-    logMsgToConfigSysLog "ERROR" "ERROR: This scripts need a Gen2 account. Please contact Loggly support."
-    exit 1
-  else
-    echo "INFO: It is a Gen2 account."
-  fi
 }
 
 #check if user name and password is valid

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -506,7 +506,7 @@ checkAuthTokenAndWriteContents() {
 setPathToCABundle () {
   case "$LINUX_DIST_IN_LOWER_CASE" in
   *"debian"* | *"ubuntu"*)
-    CA_PATH="/etc/ssl/certs/ca-certificates.crt"
+    CA_FILE_PATH="/etc/ssl/certs/ca-certificates.crt"
     ;;
   *"red"* | *"centos"* | *"amazon"*)
     CA_PATH="/etc/ssl/certs/ca-bundle.crt"

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -503,9 +503,22 @@ checkAuthTokenAndWriteContents() {
   fi
 }
 
+setPathToCABundle () {
+  case "$LINUX_DIST_IN_LOWER_CASE" in
+  *"debian"* | *"ubuntu"*)
+    CA_PATH="/etc/ssl/certs/ca-certificates.crt"
+    ;;
+  *"red"* | *"centos"* | *"amazon"*)
+    CA_PATH="/etc/ssl/certs/ca-bundle.crt"
+    ;;
+  *)
+    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to CA bundle of your linux distribution in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA bundle is '$CA_PATH'."
+    ;;
+  esac
 }
 
 confString() {
+  setPathToCABundle
   RSYSLOG_VERSION_TMP=$(echo $RSYSLOG_VERSION | cut -d "." -f1)
   inputStr_TLS_RSYS_7="
 #          -------------------------------------------------------


### PR DESCRIPTION
**Description**
- [JIRA](https://swicloud.atlassian.net/browse/LOG-8159)
- https://www.loggly.com/docs/sending-logs-unixlinux-system-setup/
- replace usage of the Loggly certificate for using CA bundle stored in OS trust store -> this bundle contains all public root certificates
- path (CA_PATH) is selected based on Linux distribution -> compatible with debian, ubuntu, centos, rhel and ami
- verified on Ubuntu 18.04., CentOS 8, RHEL8, Amazon AMI 2, Debian 9
- remove checking of gen2 account 

**Steps to verify**
1. copy script to Linux distribution
2. run script `sudo bash configure-linux.sh - a <subdomain> -u <user>`