### PR TITLE
[LOG-8201] Linux file monitoring script update - use truststore

### DIFF
--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -405,7 +405,7 @@ write21ConfFileContents() {
             \$ActionSendStreamDriverPermittedPeer *.loggly.com
 
             #RsyslogGnuTLS
-            \$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+            \$DefaultNetstreamDriverCAFile $CA_FILE_PATH
 
             # File access file:
             \$InputFileName $FILE_TO_MONITOR
@@ -445,7 +445,7 @@ write21ConfFileContents() {
             module(load=\"imfile\")
 
             #RsyslogGnuTLS
-            \$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+            \$DefaultNetstreamDriverCAFile $CA_FILE_PATH
 
             # Input for FILE1
             input(type=\"imfile\" tag=\"$LOGGLY_FILE_TO_MONITOR_ALIAS\" ruleset=\"filelog\" file=\"$FILE_TO_MONITOR\") #wildcard is allowed at file level only

--- a/Modular Scripts/File Monitoring/configure-file-monitoring.sh
+++ b/Modular Scripts/File Monitoring/configure-file-monitoring.sh
@@ -9,7 +9,7 @@ source configure-linux.sh "being-invoked"
 #name of the current script
 SCRIPT_NAME=configure-file-monitoring.sh
 #version of the current script
-SCRIPT_VERSION=1.15
+SCRIPT_VERSION=1.16
 
 #file to monitor (contains complete path and file name) provided by user
 LOGGLY_FILE_TO_MONITOR=


### PR DESCRIPTION
**Description:**
- https://swicloud.atlassian.net/browse/LOG-8201
- replace `$DefaultNetstreamDriverCAFile` path to Loggly certificate for the path to CA bundle (root certificates) stored in OS truststore
-more information: https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/upgrade-tls-certificate.htm
- verified on supported distributions: Ubuntu, Debian, RHEL, CentOS , Amazon AMI
- upload to the public available S3 bucket will be done in [JIRA ticket](https://swicloud.atlassian.net/browse/LOG-8469)
- for testing: it's necessary to use/download the newest version of [configure-linux.sh](https://github.com/loggly/install-script/blob/master/Linux%20Script/configure-linux.sh) script + remove the 5th line (_curl ..._) in configure-file-monitoring.sh 