### PR TITLE
[LOG-8200] Apache script update - use truststore

### DIFF
--- a/Modular Scripts/Apache2/configure-apache.sh
+++ b/Modular Scripts/Apache2/configure-apache.sh
@@ -9,7 +9,7 @@ source configure-linux.sh "being-invoked"
 #name of the current script
 SCRIPT_NAME=configure-apache.sh
 #version of the current script
-SCRIPT_VERSION=1.6
+SCRIPT_VERSION=1.7
 
 #we have not found the apache version yet at this point in the script
 APP_TAG="\"apache-version\":\"\""

--- a/Modular Scripts/Apache2/configure-apache.sh
+++ b/Modular Scripts/Apache2/configure-apache.sh
@@ -267,7 +267,7 @@ write21ApacheFileContents() {
     \$ActionSendStreamDriverPermittedPeer *.loggly.com
     
     #RsyslogGnuTLS
-    \$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+    \$DefaultNetstreamDriverCAFile $CA_FILE_PATH
         
     # Apache access file:
     \$InputFileName $LOGGLY_APACHE_LOG_HOME/$APACHE_ACCESS_LOG_FILE


### PR DESCRIPTION
**Description:**
- https://swicloud.atlassian.net/browse/LOG-8200
- replace $DefaultNetstreamDriverCAFile path to Loggly certificate for the path to CA bundle (root certificates) stored in OS truststore
- more information: https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/upgrade-tls-certificate.htm
- verified on supported distributions: Ubuntu, Debian, RHEL, CentOS , Amazon AMI
- upload to the public available S3 bucket will be done in JIRA ticket 
- for testing: it's necessary to use/download the newest version of configure-linux.sh script + remove the 5th line (curl ...) in configure-apache.sh