### PR TITLE
[LOG-8203] Update tomcat script

### DIFF
--- a/Modular Scripts/Tomcat/configure-tomcat.sh
+++ b/Modular Scripts/Tomcat/configure-tomcat.sh
@@ -9,7 +9,7 @@ source configure-linux.sh "being-invoked"
 #name of the current script
 SCRIPT_NAME=configure-tomcat.sh
 #version of the current script
-SCRIPT_VERSION=1.6
+SCRIPT_VERSION=1.7
 
 #minimum version of tomcat to enable log rotation
 MIN_TOMCAT_VERSION=6.0.33.0

--- a/Modular Scripts/Tomcat/configure-tomcat.sh
+++ b/Modular Scripts/Tomcat/configure-tomcat.sh
@@ -522,7 +522,7 @@ write21TomcatFileContents() {
 \$ActionSendStreamDriverPermittedPeer *.loggly.com
 
 #RsyslogGnuTLS
-\$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+\$DefaultNetstreamDriverCAFile $CA_FILE_PATH
 
 #parameterized token here.......
 #Add a tag for tomcat events


### PR DESCRIPTION
## Description
[JIRA task link](https://swicloud.atlassian.net/browse/LOG-8203)
Replaced cert file `$DefaultNetstreamDriverCAFile` path to the path in the truststore. 
Verified on Debian.

## Testing
download the updated tomcat script and run it