### PR TITLE
[LOG-8202] Update CA path for nginx script

### DIFF
--- a/Modular Scripts/Nginx/configure-nginx.sh
+++ b/Modular Scripts/Nginx/configure-nginx.sh
@@ -229,7 +229,7 @@ write21NginxFileContents() {
     \$ActionSendStreamDriverPermittedPeer *.loggly.com
     
     #RsyslogGnuTLS
-    \$DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/logs-01.loggly.com_sha12.crt
+    \$DefaultNetstreamDriverCAFile $CA_FILE_PATH
     
     # nginx access file:
     \$InputFileName $LOGGLY_NGINX_LOG_HOME/$NGINX_ACCESS_LOG_FILE

--- a/Modular Scripts/Nginx/configure-nginx.sh
+++ b/Modular Scripts/Nginx/configure-nginx.sh
@@ -9,7 +9,7 @@ source configure-linux.sh "being-invoked"
 #name of the current script
 SCRIPT_NAME=configure-nginx.sh
 #version of the current script
-SCRIPT_VERSION=1.4
+SCRIPT_VERSION=1.5
 
 #we have not found the nginx version yet at this point in the script
 APP_TAG="\"nginx-version\":\"\""


### PR DESCRIPTION
**Description:**
- https://swicloud.atlassian.net/browse/LOG-8202
- replace $DefaultNetstreamDriverCAFile path to Loggly certificate for the path to CA bundle (root certificates) stored in OS truststore
- more information: https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/upgrade-tls-certificate.htm
- verified on supported distributions: Ubuntu, Debian, RHEL, CentOS , Amazon AMI
- upload to the public available S3 bucket will be done in different JIRA ticket 

**Testing:**
- download this version of script and run it

