### PR TITLE
LOG-7362 Updated message when the S3 bucket is not found.

### DIFF
--- a/AWSscripts/SQS3script.py
+++ b/AWSscripts/SQS3script.py
@@ -287,7 +287,8 @@ def get_args():
 def get_bucket(session, bucket_name):
     bucket = session.resource('s3').Bucket(bucket_name)
     if bucket.creation_date is None:
-        print('S3 bucket {} does not exist, please create it and run the script again'.format(bucket_name))
+        region = boto3.session.Session().region_name
+        print('\033[91m', 'S3 bucket {} does not exist, please create it and run the script again. Also, make sure the S3 bucket and the SQS queue are in the same region. Current session region: {}'.format(bucket_name, region))
         sys.exit(1)
     return bucket
 


### PR DESCRIPTION
**SQS3script.py updated**

A purpose of this update is that when the script does not find the S3 bucket, it might be caused by the fact the SQS queue and the S3 bucket are in different regions, which is not supported by AWS. This is displayed to the user who runs the script, when the bucket is not found. 

Next step is to update documentation.