### PR TITLE
LOG-12482 fix reading token

### DIFF
--- a/Linux Script/README.md
+++ b/Linux Script/README.md
@@ -1,11 +1,19 @@
-Linux Script
-============
+# Linux Script
+
+## Configure
 
 Configure your Linux system to send syslogs to Loggly using the following command
 
-    sudo bash configure-linux.sh -a SUBDOMAIN -u USERNAME 
-    
+```bash
+sudo bash configure-linux.sh -a SUBDOMAIN -u USERNAME 
+```
+
+You can also pass your *customer token* as `-t TOKEN`. If it's omitted, the token will be loaded automatically.
+
+## Stop
 
 Stop sending your Linux System logs to Loggly
 
-    sudo bash configure-linux.sh -a SUBDOMAIN -r
+```bash
+sudo bash configure-linux.sh -a SUBDOMAIN -r
+```

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -384,10 +384,7 @@ getAuthToken() {
   if [ "$LOGGLY_AUTH_TOKEN" = "" ]; then
     logMsgToConfigSysLog "INFO" "INFO: Authentication token not provided. Trying to retrieve it from $LOGGLY_ACCOUNT_URL account."
     #get authentication token if user has not provided one
-    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -v "token")
-
-    #get the string from index 0 to first occurence of ,
-    tokenstr=${tokenstr%%,*}
+    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -A1 "token" | grep -v "token")
 
     #get the string from index 0 to last occurence of "
     tokenstr=${tokenstr%\"*}

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -495,7 +495,7 @@ checkAuthTokenAndWriteContents() {
     writeContents $LOGGLY_ACCOUNT $LOGGLY_AUTH_TOKEN $LOGGLY_DISTRIBUTION_ID $LOGS_01_HOST $LOGGLY_SYSLOG_PORT
     restartRsyslog
   else
-    logMsgToConfigSysLog "ERROR" "ERROR: Loggly auth token is required to configure rsyslog. Please pass -a <auth token> while running script."
+    logMsgToConfigSysLog "ERROR" "ERROR: Loggly auth token is required to configure rsyslog. Please pass -t <auth token> while running script."
     exit 1
   fi
 }
@@ -509,7 +509,7 @@ setPathToCABundle () {
     CA_FILE_PATH="/etc/ssl/certs/ca-bundle.crt"
     ;;
   *)
-    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to the file with root CA certificates (usually stored in OS trust store) in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--inssecure' attribute. Default path to CA file is '$CA_FILE_PATH'."
+    logMsgToConfigSysLog "WARN" "WARN: The linux distribution '$LINUX_DIST' has not been previously tested with Loggly. Verify path to the file with root CA certificates (usually stored in OS trust store) in '$RSYSLOG_ETCDIR_CONF' -> '\$DefaultNetstreamDriverCAFile' and restart rsyslog service or re-run script with '--insecure' attribute. Default path to CA file is '$CA_FILE_PATH'."
     ;;
   esac
 }

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -384,7 +384,7 @@ getAuthToken() {
   if [ "$LOGGLY_AUTH_TOKEN" = "" ]; then
     logMsgToConfigSysLog "INFO" "INFO: Authentication token not provided. Trying to retrieve it from $LOGGLY_ACCOUNT_URL account."
     #get authentication token if user has not provided one
-    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -A1 "\"tokens\"" | grep -v "tokens")
+    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -A1 "\"tokens\":" | grep -v "tokens")
 
     #get the string from index 0 to last occurence of "
     tokenstr=${tokenstr%\"*}

--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -384,7 +384,7 @@ getAuthToken() {
   if [ "$LOGGLY_AUTH_TOKEN" = "" ]; then
     logMsgToConfigSysLog "INFO" "INFO: Authentication token not provided. Trying to retrieve it from $LOGGLY_ACCOUNT_URL account."
     #get authentication token if user has not provided one
-    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -A1 "token" | grep -v "token")
+    tokenstr=$(curl -s -u $LOGGLY_USERNAME:$LOGGLY_PASSWORD $LOGGLY_ACCOUNT_URL/apiv2/customer | grep -A1 "\"tokens\"" | grep -v "tokens")
 
     #get the string from index 0 to last occurence of "
     tokenstr=${tokenstr%\"*}


### PR DESCRIPTION
https://swicloud.atlassian.net/browse/LOG-12482

**Summary:**
When parsing token from json we were expecting the "tokens" attribute to be at the first place in the json structure. Maybe with python update the json structure changed a bit, now "tokens" attr is not at the first place which causes parsing the token to fail. I changed the parsing to take the first token and not to care about the position of the attributes.

**How to test:**
- have Linux environment (I used Loggly container which runs Linux - you will need to install additional packages by: `apt-get update & apt-get install iputils-ping & apt-get install rsyslog rsyslog-doc`, but it would be great if you could use something else so we'll have it tested in different environments)
- get the script `Linux Scripts/configure-linux.sh`
- before running the script you might need to set its permissions first: `chmod +x configure-linux.sh`
- run the script: `./configure-linux.sh -a SUBDOMAIN -u USERNAME` (you will be asked for a password) (note: I had to let it go into insecure mode)
	- before the fix, it fails with “Invalid authentication token”
	- the script should set up everything and send some logs to Loggly, you should be able to find them there (for me it said that it cannot find the loggly test message, but I was able to see it there. When running it again it was all ok)
	- if everything went ok, you should be able to send logs to Loggly by `logger ”test”`