### PR TITLE
LOG-12569 Put rsyslog version arguments into quotes

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -462,7 +462,7 @@ checkIfMinVersionOfRsyslog() {
   RSYSLOG_VERSION=${RSYSLOG_VERSION#* }
   RSYSLOG_VERSION=${RSYSLOG_VERSION%,*}
   RSYSLOG_VERSION=$RSYSLOG_VERSION | tr -d " "
-  if [ $(compareVersions $RSYSLOG_VERSION $MIN_RSYSLOG_VERSION 3) -lt 0 ]; then
+  if [ $(compareVersions "$RSYSLOG_VERSION" "$MIN_RSYSLOG_VERSION" 3) -lt 0 ]; then
     logMsgToConfigSysLog "ERROR" "ERROR: Minimum rsyslog version required to run this script is 5.8.0. Please upgrade your rsyslog version or follow the manual instructions."
     exit 1
   fi


### PR DESCRIPTION
https://swicloud.atlassian.net/browse/LOG-12569

When comparing versions of rsyslog there was a bug where arguments wouldn't match because of a space.
Surrounding this variables with quotes prevent the arguments to split.