### PR TITLE
LOG-12594 Fix fetching of rsid in search request

### DIFF
--- a/Linux Script/configure-linux.sh
+++ b/Linux Script/configure-linux.sh
@@ -883,7 +883,7 @@ searchAndFetch() {
   # remove newline characters
   result=${result//$'\n'/}
 
-  id=$(echo "$result" | sed -E 's/.*"id": +"([0-9]+)".*/\1/g')
+  id=$(echo "$result" | sed -E 's/.*"id"\s*:\s*"([^"]+)".*/\1/g')
 
   url="$LOGGLY_ACCOUNT_URL/apiv2/events?rsid=$id"
 


### PR DESCRIPTION
Fix for CI: https://swicloud.atlassian.net/browse/LOG-12594

The `configure-file-monitoring.sh` script is using `configure-linux.sh` script to send and fetch events to/from Loggly.
This script is using the `/apiv2/search?...` endpoint, which returns the following JSON:
```
{
  "rsid": {
    "status": "PENDING",
    "date_to": 1629977679861,
    "date_from": 1629891279861,
    "id": "1629977679861932906",
    "elapsed_time": 0.013359081000089645
  }
}
```
From which the `id` is used to fetch the actual results.

I presume that we added `elapsed_time`, or that the ordering has changed, because the script is assuming that the `id` will be in the last position, and trims the first and latest quote to get the id. With the additional comma this fetching broke and even though events were indeed in Loggly, the customer received an error message instead.

With this, the `id` should be fetched no matter the position in the JSON.

How to test:
```
#!/bin/bash

result='{
 "rsid":{
  "status": "PENDING",
  "date_to": 1629977679861,
  "date_from": 1629891279861,
  "id": "1629977679861932906",
  "elapsed_time": 0.013359081000089645
 }
}'

result=${result//$'\n'/}
id=$(echo "$result" | sed -E 's/.*"id": +"([0-9]+)".*/\1/g')

echo $id
```
Returns `1629977679861932906`